### PR TITLE
New values to improve latency stability and sound quality

### DIFF
--- a/utils/cmtspeech_ofono_test.c
+++ b/utils/cmtspeech_ofono_test.c
@@ -436,14 +436,14 @@ static void test_handle_cmtspeech_data_upload(struct test_ctx *ctx)
 			fprintf(stderr, __FILE__": pa_simple_get_latency() failed: %s\n", pa_strerror(error));
 			exit(1);
 		}
-#if 0
+//#if 0
 		if (latency_r < 100000) {
 		  fprintf(stderr, "...skip latency (%d)\n", latency_r);
 			break;
 		}
-#endif
+//#endif
 
-		if (latency_r > 400000) {
+		if (latency_r > 200000) {
 			int scratch_int;
 		  fprintf(stderr, "...flush latency (%d)\n", latency_r);
 		  error = audio_read(ctx->source, scratch, 2048);

--- a/utils/cmtspeech_ofono_test.c
+++ b/utils/cmtspeech_ofono_test.c
@@ -520,7 +520,6 @@ static int test_handle_cmtspeech_control(struct test_ctx *ctx)
       break;
 
     case CMTSPEECH_TR_1_CONNECTED:
-        sleep(2);
     case CMTSPEECH_TR_2_DISCONNECTED:
 	    break;
     case CMTSPEECH_TR_3_DL_START:

--- a/utils/pulse.c
+++ b/utils/pulse.c
@@ -57,15 +57,16 @@ static const pa_sample_spec ss = {
 	.rate = 4000,
 	.channels = 2
 /* alternate-sample-rate must be 4000 in /etc/pulse/daemon.conf to get calls working both ways*/
+/* (alternate-sample-rate = 44100 and sample-rate = 48000 work as well now) */
 };
 static const pa_buffer_attr pa_attr = {
 	.fragsize = (uint32_t) 256,
 	.maxlength = (uint32_t) -1,
-	.minreq = (uint32_t) 256,
+	.minreq = (uint32_t) -1,
 	.prebuf = (uint32_t) -1,
-	.tlength = (uint32_t) 256,
-	/*fragsize / minreq / tlenght must be 256 to get 2G calls working, no real inpact on 3G calls ATM*/
-	/* fragsize / tlength can be 4096> pulseaudio CPU drops from 33% CPU to 10%, but latency can be heard */
+	.tlength = (uint32_t) 4096,
+/*fragsize / minreq / tlenght must be 256 to get 2G calls working, no real inpact on 3G calls ATM*/
+/*got better result with fragsize 256 and tlength 4096 using chrt realtime priorities */
 };
 
 static void start_sink(struct test_ctx *ctx)


### PR DESCRIPTION
These 2 commits help to increase stability and now 2G-3G-3.5G calls are similar in terms of latency and sound quality.
Note: chrt commands to use ATM (sudo):
chrt -r -p 99 $(pgrep sphone)
chrt -f -p 99 $(pgrep cmt_pulse)
chrt -f -p 99 $(pgrep pulseaudio)
