### PR TITLE
Compile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ libcmtspeech.a: cmtspeech_config.h
 	done
 	ar rcs libcmtspeech.a cmtspeech_backend_common.o cmtspeech_msgs.o cmtspeech_nokiamodem.o sal_debug.o
 
-CFLAGS_CMT = -g -I . -I /usr/include/dbus-1.0/ -I /usr/lib/arm-linux-gnueabihf/dbus-1.0/include/ utils/cmtspeech_ofono_test.c -lpthread -lrt libcmtspeech.a /usr/lib/arm-linux-gnueabihf/libdbus-1.a -lm
+CFLAGS_CMT = -g -I . -I /usr/include/dbus-1.0/ -I /usr/lib/arm-linux-gnueabihf/dbus-1.0/include/ utils/cmtspeech_ofono_test.c -lpthread -lrt libcmtspeech.a -ldbus-1 -lm
 
 CFLAGS_ATEST = -g atest.c
 

--- a/alsa_test.c
+++ b/alsa_test.c
@@ -498,7 +498,7 @@ int main(int argc, char *argv[])
 		printf("Capture:\n");
 		showstat(chandle, frames_in);
 		showinmax(in_max);
-		if (p_tstamp.tv_sec == p_tstamp.tv_sec &&
+		if (p_tstamp.tv_sec == c_tstamp.tv_sec &&
 		    p_tstamp.tv_usec == c_tstamp.tv_usec)
 			printf("Hardware sync\n");
 		snd_pcm_drop(chandle);

--- a/dsp2.c
+++ b/dsp2.c
@@ -6,11 +6,11 @@ struct test_ctx {
 };
 
 #include "utils/dsp.c"
+#include "utils/audio.h"
 
 /*
  * Mandatory variables.
  */
-#define SSIZE 4096
 int audio_fd;  
 char silence[SSIZE];
 

--- a/utils/alsa.c
+++ b/utils/alsa.c
@@ -388,7 +388,7 @@ static void start_sink(struct test_ctx *ctx)
 
 	snd_pcm_dump(phandle, output);
 	
-	printf("initial write: %d\n", audio_write(ctx->sink, zero_buf, 3*1024));
+	printf("initial write: %ld\n", audio_write(ctx->sink, zero_buf, 3*1024));
 }
 
 static void start_source(struct test_ctx *ctx)

--- a/utils/alsa.c
+++ b/utils/alsa.c
@@ -10,6 +10,8 @@
 #include <sys/time.h>
 #include <math.h>
 
+#include "audio.h"
+
 #define DRIVER_NAME "alsa"
 
 /*

--- a/utils/audio.c
+++ b/utils/audio.c
@@ -127,7 +127,7 @@ void wd_done(void)
  *   replace with SSIZE*4
  */
 
-char sbuf[SSIZE*8];
+short int sbuf[SSIZE*8];
 
 #ifdef MAN_STEREO
 ssize_t audio_read(audio_t fd, void *buf, size_t count)

--- a/utils/audio.c
+++ b/utils/audio.c
@@ -6,23 +6,9 @@
 #include <stdio.h>
 #include <math.h>
 
-typedef int16_t s16;
+#include "audio.h"
 
-#ifdef ALSA
-#include <alsa/asoundlib.h>
-typedef snd_pcm_t * audio_t;
-#endif
-#ifdef PULSE
-#include <pulse/simple.h>
-#include <pulse/error.h>
-typedef pa_simple * audio_t;
-#endif	
-#ifdef DSP
-typedef int audio_t;
-#endif
-#ifndef PULSE
-typedef long long pa_usec_t;
-#endif
+typedef int16_t s16;
 
 struct test_ctx {
 #ifdef CMT_REAL
@@ -137,15 +123,18 @@ void wd_done(void)
 	wd_write("no\n");
 }
 
-#define SSIZE (16*1024)
-char sbuf[SSIZE*2];
+/* #define SSIZE (16*1024)
+ *   replace with SSIZE*4
+ */
+
+char sbuf[SSIZE*8];
 
 #ifdef MAN_STEREO
 ssize_t audio_read(audio_t fd, void *buf, size_t count)
 {
 	static float gain = 3;
 	ssize_t res;
-	if (count > SSIZE) {
+	if (count > SSIZE*4) {
 		printf("Too big request\n");
 		exit(1);
 	}
@@ -159,7 +148,7 @@ ssize_t audio_write(audio_t fd, void *buf, size_t count)
 {
 	static float gain = 3;
 	ssize_t res;
-	if (count > SSIZE) {
+	if (count > SSIZE*4) {
 		printf("Too big request\n");
 		exit(1);
 	}

--- a/utils/audio.c
+++ b/utils/audio.c
@@ -203,7 +203,7 @@ ssize_t audio_write(audio_t fd, void *buf, size_t count)
 }
 #endif
 
-ssize_t audio_generate(s16 *buf, size_t count)
+void audio_generate(s16 *buf, size_t count)
 {
 	int i;
 	for (i = 0; i < count/2; i++) {

--- a/utils/audio.h
+++ b/utils/audio.h
@@ -1,3 +1,20 @@
 #define SSIZE 4096
+
+#ifdef ALSA
+#include <alsa/asoundlib.h>
+typedef snd_pcm_t * audio_t;
+#endif
+#ifdef PULSE
+#include <pulse/simple.h>
+#include <pulse/error.h>
+typedef pa_simple * audio_t;
+#endif
+#ifdef DSP
+typedef int audio_t;
+#endif
+#ifndef PULSE
+typedef long long pa_usec_t;
+#endif
+
 ssize_t audio_write(audio_t fd, void *buf, size_t count);
 

--- a/utils/audio.h
+++ b/utils/audio.h
@@ -1,0 +1,3 @@
+#define SSIZE 4096
+ssize_t audio_write(audio_t fd, void *buf, size_t count);
+

--- a/utils/dsp.c
+++ b/utils/dsp.c
@@ -12,6 +12,8 @@
 #include <stdlib.h>
 #include <errno.h>
 
+#include "utils/audio.h"
+
 #define DRIVER_NAME "dsp"
 
 ssize_t audio_read_raw(int fd, void *buf, size_t count)
@@ -136,7 +138,6 @@ int audio_open(int speed)
 
 static void start_source(struct test_ctx *ctx)
 {
-#define SSIZE 4096
 	static char silence[SSIZE];
 	audio_write(ctx->sink, silence, SSIZE);
 }

--- a/utils/pulse.c
+++ b/utils/pulse.c
@@ -4,9 +4,9 @@
 
 static int pa_errno;
 
-long audio_read_raw(pa_simple *handle, char *buf, long len)
+long audio_read_raw(pa_simple *handle, char *buf, int len)
 {
-	size_t frames = len;
+	int frames = len;
 	int error;
 
 	error = pa_simple_read(handle, buf, len, &frames);
@@ -17,7 +17,7 @@ long audio_read_raw(pa_simple *handle, char *buf, long len)
 	return frames;
 }
 
-long audio_write_raw(pa_simple *handle, char *buf, long len)
+long audio_write_raw(pa_simple *handle, char *buf, int len)
 {
 	int frames = len;
 	int error;


### PR DESCRIPTION
This attempts to fix the numerous compile errors with libcmtspeechdata. Hopefully does not introduce any regressions.